### PR TITLE
fix: enforce boolean types in travel tables

### DIFF
--- a/client/src/lib/sessionManager.ts
+++ b/client/src/lib/sessionManager.ts
@@ -278,6 +278,13 @@ class SessionManager {
   }
 
   /**
+   * Get user ID for current session
+   */
+  getUserId(): string | null {
+    return this.currentSession?.userId || null;
+  }
+
+  /**
    * Set user ID for current session
    */
   async setUserId(userId: string): Promise<void> {

--- a/shared/travelTables.ts
+++ b/shared/travelTables.ts
@@ -69,7 +69,7 @@ export const travelArchetypes = pgTable("travel_archetypes", {
   travelStyle: varchar("travel_style", { length: 50 }),
   themeColors: jsonb("theme_colors"), // UI color scheme
   icon: text("icon"),
-  isActive: boolean("is_active").default(true),
+  isActive: boolean("is_active").default(true).notNull(),
   createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at").defaultNow(),
 });
@@ -81,7 +81,7 @@ export const travelQuizQuestions = pgTable("travel_quiz_questions", {
   question: text("question").notNull(),
   options: jsonb("options").notNull(), // array of {text, value, archetype_weight}
   order: integer("order").notNull(),
-  isActive: boolean("is_active").default(true),
+  isActive: boolean("is_active").default(true).notNull(),
   createdAt: timestamp("created_at").defaultNow(),
 });
 
@@ -121,7 +121,7 @@ export const travelOffers = pgTable("travel_offers", {
   priority: integer("priority").default(0),
   clicks: integer("clicks").default(0),
   conversions: integer("conversions").default(0),
-  isActive: boolean("is_active").default(true),
+  isActive: boolean("is_active").default(true).notNull(),
   createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at").defaultNow(),
 });
@@ -142,7 +142,7 @@ export const travelItineraries = pgTable("travel_itineraries", {
   season: varchar("season", { length: 20 }), // best season
   featuredImage: text("featured_image"),
   gallery: jsonb("gallery"),
-  isPublic: boolean("is_public").default(true),
+  isPublic: boolean("is_public").default(true).notNull(),
   likes: integer("likes").default(0),
   saves: integer("saves").default(0),
   views: integer("views").default(0),
@@ -161,7 +161,7 @@ export const travelTools = pgTable("travel_tools", {
   description: text("description"),
   toolType: varchar("tool_type", { length: 50 }).notNull(), // budget, packing, visa, etc.
   config: jsonb("config"), // tool-specific configuration
-  isActive: boolean("is_active").default(true),
+  isActive: boolean("is_active").default(true).notNull(),
   order: integer("order").default(0),
   icon: text("icon"),
   createdAt: timestamp("created_at").defaultNow(),
@@ -181,7 +181,7 @@ export const travelUserSessions = pgTable("travel_user_sessions", {
   quizResults: jsonb("quiz_results"),
   deviceInfo: jsonb("device_info"),
   location: jsonb("location"),
-  isActive: boolean("is_active").default(true),
+  isActive: boolean("is_active").default(true).notNull(),
   lastActivity: timestamp("last_activity").defaultNow(),
   createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at").defaultNow(),
@@ -195,7 +195,7 @@ export const travelContentSources = pgTable("travel_content_sources", {
   sourceType: varchar("source_type", { length: 50 }).notNull(), // blog, api, social
   selectors: jsonb("selectors"), // CSS selectors for scraping
   lastScraped: timestamp("last_scraped"),
-  scrapingEnabled: boolean("scraping_enabled").default(true),
+  scrapingEnabled: boolean("scraping_enabled").default(true).notNull(),
   priority: integer("priority").default(0),
   tags: jsonb("tags"),
   createdAt: timestamp("created_at").defaultNow(),


### PR DESCRIPTION
## Summary
- ensure travel table boolean defaults are non-null

## Testing
- `npm run check` *(fails: Property 'getUserId' does not exist on type 'SessionManager', among other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e3a9b10c833184f2223bf86ea9e6