### PR TITLE
feat: add minimal python neuron example

### DIFF
--- a/README_API_NEURON_PYTHON.md
+++ b/README_API_NEURON_PYTHON.md
@@ -4,6 +4,18 @@
 
 This document provides a complete guide for building and deploying Python-based API-only neurons that integrate with the Findawise Empire Federation. API-only neurons are backend services, data processors, scrapers, ML models, or microservices that participate in the federation without a UI component.
 
+## Quickstart
+
+A minimal FastAPI neuron is provided at `_python_tools/neuron.py`. To run it locally:
+
+```bash
+cd _python_tools
+python -m pip install -r requirements-neuron.txt
+uvicorn neuron:app --reload --port 8000
+```
+
+The neuron registers with the federation at `FEDERATION_API` (default `http://localhost:3000`) and sends heartbeats every `HEARTBEAT_INTERVAL` seconds.
+
 ## What is an API-Only Neuron?
 
 An API-only neuron is a backend service that:

--- a/README_API_NEURON_PYTHON.md
+++ b/README_API_NEURON_PYTHON.md
@@ -15,6 +15,7 @@ uvicorn neuron:app --reload --port 8000
 ```
 
 The neuron registers with the federation at `FEDERATION_API` (default `http://localhost:3000`) and sends heartbeats every `HEARTBEAT_INTERVAL` seconds.
+The example uses an asynchronous `httpx` client so network calls don't block the event loop.
 
 ## What is an API-Only Neuron?
 

--- a/_python_tools/neuron.py
+++ b/_python_tools/neuron.py
@@ -3,10 +3,12 @@ import os
 from typing import Any, Dict
 
 
-import requests
+import httpx
 from fastapi import FastAPI
+import logging
 
 app = FastAPI()
+logger = logging.getLogger(__name__)
 
 NEURON_ID = os.getenv("NEURON_ID", "python-neuron")
 FEDERATION_API = os.getenv("FEDERATION_API", "http://localhost:3000")
@@ -27,22 +29,23 @@ async def register() -> None:
         ],
     }
     try:
-        requests.post(f"{FEDERATION_API}/api/neuron/register", json=payload, timeout=5)
+        async with httpx.AsyncClient(timeout=5) as client:
+            await client.post(f"{FEDERATION_API}/api/neuron/register", json=payload)
     except Exception as exc:  # pragma: no cover - best effort
-        print(f"Registration failed: {exc}")
+        logger.warning("Registration failed: %s", exc)
 
 
 async def heartbeat() -> None:
     """Send periodic heartbeat messages."""
     while True:
         try:
-            requests.post(
-                f"{FEDERATION_API}/api/neuron/status",
-                json={"neuronId": NEURON_ID, "status": "active"},
-                timeout=5,
-            )
+            async with httpx.AsyncClient(timeout=5) as client:
+                await client.post(
+                    f"{FEDERATION_API}/api/neuron/status",
+                    json={"neuronId": NEURON_ID, "status": "active"},
+                )
         except Exception as exc:  # pragma: no cover - best effort
-            print(f"Heartbeat failed: {exc}")
+            logger.warning("Heartbeat failed: %s", exc)
         await asyncio.sleep(HEARTBEAT_INTERVAL)
 
 

--- a/_python_tools/neuron.py
+++ b/_python_tools/neuron.py
@@ -1,0 +1,63 @@
+import asyncio
+import os
+from typing import Any, Dict
+
+
+import requests
+from fastapi import FastAPI
+
+app = FastAPI()
+
+NEURON_ID = os.getenv("NEURON_ID", "python-neuron")
+FEDERATION_API = os.getenv("FEDERATION_API", "http://localhost:3000")
+BASE_URL = os.getenv("BASE_URL", "http://localhost:8000")
+HEARTBEAT_INTERVAL = int(os.getenv("HEARTBEAT_INTERVAL", "60"))
+
+
+async def register() -> None:
+    """Register this neuron with the federation."""
+    payload = {
+        "neuronId": NEURON_ID,
+        "name": "Python Example Neuron",
+        "language": "python",
+        "baseUrl": BASE_URL,
+        "healthcheckEndpoint": "/health",
+        "apiEndpoints": [
+            {"path": "/process", "method": "POST", "description": "Echo input"}
+        ],
+    }
+    try:
+        requests.post(f"{FEDERATION_API}/api/neuron/register", json=payload, timeout=5)
+    except Exception as exc:  # pragma: no cover - best effort
+        print(f"Registration failed: {exc}")
+
+
+async def heartbeat() -> None:
+    """Send periodic heartbeat messages."""
+    while True:
+        try:
+            requests.post(
+                f"{FEDERATION_API}/api/neuron/status",
+                json={"neuronId": NEURON_ID, "status": "active"},
+                timeout=5,
+            )
+        except Exception as exc:  # pragma: no cover - best effort
+            print(f"Heartbeat failed: {exc}")
+        await asyncio.sleep(HEARTBEAT_INTERVAL)
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    await register()
+    asyncio.create_task(heartbeat())
+
+
+@app.get("/health")
+async def health() -> Dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/process")
+async def process(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Echo the received payload back to the caller."""
+    return {"received": payload}

--- a/_python_tools/requirements-neuron.txt
+++ b/_python_tools/requirements-neuron.txt
@@ -5,6 +5,8 @@
 requests>=2.31.0
 psutil>=5.9.0
 schedule>=1.2.0
+fastapi>=0.110.0
+uvicorn>=0.24.0
 
 # Optional but recommended for production
 prometheus-client>=0.17.0  # For metrics export
@@ -12,3 +14,4 @@ sentry-sdk>=1.32.0        # For error tracking
 python-dotenv>=1.0.0      # For environment management
 pydantic>=2.0.0           # For data validation
 structlog>=23.1.0         # For structured logging
+

--- a/_python_tools/requirements-neuron.txt
+++ b/_python_tools/requirements-neuron.txt
@@ -2,7 +2,7 @@
 # ==========================================
 
 # Core dependencies
-requests>=2.31.0
+httpx>=0.25.0
 psutil>=5.9.0
 schedule>=1.2.0
 fastapi>=0.110.0


### PR DESCRIPTION
## Summary
- add FastAPI-based neuron with /health and /process endpoints
- include federation registration and heartbeat logic hitting /api/neuron/*
- document running the example neuron and required dependencies

## Testing
- `python -m py_compile _python_tools/neuron.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1071d7550833187a4a9341364abc8