### PR TITLE
feat: mount federation router

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -113,7 +113,6 @@ import { notificationRoutes } from "./routes/notifications";
 import { createTravelRoutes } from "./routes/travel";
 import { registerEducationRoutes } from "./routes/education";
 import { createAiToolsRoutes } from "./routes/aiToolsRoutes";
-import federationRouterBridge from "./routes/federation";
 import federationDashboardRouter from "./routes/federation-dashboard";
 import apiNeuronsRouter from "./routes/apiNeurons";
 import neuronFederationRouter, { checkAndRetireStaleNeurons } from "./routes/neuronFederation";
@@ -438,7 +437,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // ===========================================
   // SPECIALIZED API ROUTES
   // ===========================================
-  app.use('/api/federation-bridge', federationRouterBridge);
+  app.use('/api/federation', federationRouter);
+  app.use('/api/federation-bridge', federationRouter);
   app.use('/api/federation-dashboard', federationDashboardRouter);
   app.use('/api/notifications', notificationRoutes);
   app.use('/api/codex', codexRouter);


### PR DESCRIPTION
## Summary
- mount `federationRouter` at `/api/federation`
- reuse router for `/api/federation-bridge` and drop redundant import

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check` *(fails: FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory)*
- `DATABASE_URL=postgres://user:pass@localhost:5432/db npm run dev` *(fails: connect ECONNREFUSED ::1:5432)*
- `curl -sS http://localhost:5000/api/federation/status` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_68c1070b1a1c83319e9f3db346ccd570