### PR TITLE
Manage heartbeat task on startup and shutdown

### DIFF
--- a/_python_tools/neuron.py
+++ b/_python_tools/neuron.py
@@ -1,0 +1,32 @@
+import asyncio
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+async def heartbeat() -> None:
+    """Send periodic heartbeat signal."""
+    while True:
+        await asyncio.sleep(60)
+
+
+heartbeat_task: asyncio.Task | None = None
+
+
+@app.on_event("startup")
+async def start_heartbeat() -> None:
+    """Start the heartbeat background task."""
+    global heartbeat_task
+    heartbeat_task = asyncio.create_task(heartbeat())
+
+
+@app.on_event("shutdown")
+async def stop_heartbeat() -> None:
+    """Cancel the heartbeat task on shutdown."""
+    global heartbeat_task
+    if heartbeat_task:
+        heartbeat_task.cancel()
+        try:
+            await heartbeat_task
+        except asyncio.CancelledError:
+            pass


### PR DESCRIPTION
## Summary
- store heartbeat background task on startup
- cancel and await heartbeat task during shutdown handling cancellation

## Testing
- `python -m py_compile _python_tools/neuron.py`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c10cf972b48331bda06d47513db6e2